### PR TITLE
feat: Add MicroComponents wrapper for rendering component arrays

### DIFF
--- a/components/ui/components/runtime/MicroComponent/MicroComponent.ts
+++ b/components/ui/components/runtime/MicroComponent/MicroComponent.ts
@@ -9,7 +9,7 @@ import { MicroAppStoreContext } from '../../../../../micro-app/state/MicroAppSto
 import { MicroAppRuntimeContext } from '../../../../../micro-app/state/MicroAppRuntimeContext';
 
 /**
- * MicroComponents - A lightweight wrapper for rendering an array of components
+ * MicroComponent - A lightweight wrapper for rendering an array of components
  *
  * Similar to MicroApp but simpler - just accepts an array of ComponentElement
  * and renders them using the existing renderComponent logic.
@@ -20,24 +20,24 @@ import { MicroAppRuntimeContext } from '../../../../../micro-app/state/MicroAppR
  *
  * @example
  * // Simple usage (shared global vars)
- * <micro-components
+ * <micro-component
  *   .components=${[
  *     { uuid: '1', component_type: 'vertical_container', root: true },
  *     { uuid: '2', component_type: 'text', input: { value: 'Hello' } }
  *   ]}
  *   .vars=${{ userName: 'John' }}
- * ></micro-components>
+ * ></micro-component>
  *
  * @example
  * // With isolated context (scoped vars)
- * <micro-components
+ * <micro-component
  *   .components=${[...]}
  *   useIsolatedContext
  *   .vars=${{ count: 0 }}
- * ></micro-components>
+ * ></micro-component>
  */
-@customElement("micro-components")
-export class MicroComponents extends LitElement {
+@customElement("micro-component")
+export class MicroComponent extends LitElement {
   static override styles = css`
     :host {
       display: block;
@@ -70,7 +70,7 @@ export class MicroComponents extends LitElement {
   @property({ type: Object }) vars?: Record<string, any>;
 
   // Isolated context instances
-  private microComponentsId: string = '';
+  private microComponentId: string = '';
   private storeContext: MicroAppStoreContext | null = null;
   private runtimeContext: MicroAppRuntimeContext | null = null;
 
@@ -107,12 +107,12 @@ export class MicroComponents extends LitElement {
    */
   private initializeIsolatedContext(): void {
     // Generate unique ID for this instance
-    this.microComponentsId = `micro-components_${uuidv4()}`;
+    this.microComponentId = `micro-component_${uuidv4()}`;
 
     // Create store context with components (no pages needed)
     this.storeContext = new MicroAppStoreContext(
-      this.microComponentsId,
-      this.microComponentsId,
+      this.microComponentId,
+      this.microComponentId,
       this.components,
       [] // no pages
     );

--- a/components/ui/components/runtime/MicroComponents/MicroComponents.ts
+++ b/components/ui/components/runtime/MicroComponents/MicroComponents.ts
@@ -1,0 +1,158 @@
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { v4 as uuidv4 } from "uuid";
+
+import { renderComponent } from '../../../../../utils/render-util';
+import type { ComponentElement } from '../../../../../redux/store/component/component.interface';
+import { ExecuteInstance } from '../../../../../state/runtime-context';
+import { MicroAppStoreContext } from '../../../../../micro-app/state/MicroAppStoreContext';
+import { MicroAppRuntimeContext } from '../../../../../micro-app/state/MicroAppRuntimeContext';
+
+/**
+ * MicroComponents - A lightweight wrapper for rendering an array of components
+ *
+ * Similar to MicroApp but simpler - just accepts an array of ComponentElement
+ * and renders them using the existing renderComponent logic.
+ *
+ * The first component in the array is treated as the root/main component.
+ *
+ * Supports optional isolated context for scoped variables.
+ *
+ * @example
+ * // Simple usage (shared global vars)
+ * <micro-components
+ *   .components=${[
+ *     { uuid: '1', component_type: 'vertical_container', root: true },
+ *     { uuid: '2', component_type: 'text', input: { value: 'Hello' } }
+ *   ]}
+ *   .vars=${{ userName: 'John' }}
+ * ></micro-components>
+ *
+ * @example
+ * // With isolated context (scoped vars)
+ * <micro-components
+ *   .components=${[...]}
+ *   useIsolatedContext
+ *   .vars=${{ count: 0 }}
+ * ></micro-components>
+ */
+@customElement("micro-components")
+export class MicroComponents extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      height: 100%;
+    }
+  `;
+
+  /**
+   * Array of component definitions to render.
+   * First component is treated as root/main.
+   */
+  @property({ type: Array }) components: ComponentElement[] = [];
+
+  /**
+   * View mode - true for preview, false for edit mode
+   */
+  @property({ type: Boolean }) isViewMode = true;
+
+  /**
+   * Enable isolated context for scoped variables.
+   * When false, vars are set on global ExecuteInstance.
+   * When true, vars are scoped to this instance only.
+   */
+  @property({ type: Boolean }) useIsolatedContext = false;
+
+  /**
+   * Initial variables to set.
+   * Works for both global and isolated modes.
+   */
+  @property({ type: Object }) vars?: Record<string, any>;
+
+  // Isolated context instances
+  private microComponentsId: string = '';
+  private storeContext: MicroAppStoreContext | null = null;
+  private runtimeContext: MicroAppRuntimeContext | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    if (this.useIsolatedContext) {
+      this.initializeIsolatedContext();
+    } else {
+      this.initializeGlobalVars();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    if (this.useIsolatedContext) {
+      this.cleanupIsolatedContext();
+    }
+    super.disconnectedCallback();
+  }
+
+  /**
+   * Set vars on global ExecuteInstance (non-isolated mode)
+   */
+  private initializeGlobalVars(): void {
+    if (this.vars) {
+      Object.entries(this.vars).forEach(([key, value]) => {
+        ExecuteInstance.VarsProxy[key] = value;
+      });
+    }
+  }
+
+  /**
+   * Initialize isolated context with scoped variables
+   */
+  private initializeIsolatedContext(): void {
+    // Generate unique ID for this instance
+    this.microComponentsId = `micro-components_${uuidv4()}`;
+
+    // Create store context with components (no pages needed)
+    this.storeContext = new MicroAppStoreContext(
+      this.microComponentsId,
+      this.microComponentsId,
+      this.components,
+      [] // no pages
+    );
+
+    // Create runtime context
+    this.runtimeContext = new MicroAppRuntimeContext(this.storeContext);
+
+    // Set initial vars on isolated context
+    if (this.vars) {
+      Object.entries(this.vars).forEach(([key, value]) => {
+        this.runtimeContext!.setVar(key, value);
+      });
+    }
+
+    // Register components in runtime
+    this.runtimeContext.registerComponents();
+  }
+
+  /**
+   * Cleanup isolated context on disconnect
+   */
+  private cleanupIsolatedContext(): void {
+    if (this.runtimeContext) {
+      this.runtimeContext.cleanup();
+      this.runtimeContext = null;
+    }
+
+    if (this.storeContext) {
+      this.storeContext.cleanup();
+      this.storeContext = null;
+    }
+  }
+
+  override render() {
+    if (!this.components?.length) return nothing;
+
+    return html`
+      <div style="height: 100%;">
+        ${renderComponent(this.components, null, this.isViewMode)}
+      </div>
+    `;
+  }
+}

--- a/micro-app-entry.ts
+++ b/micro-app-entry.ts
@@ -11,9 +11,10 @@ import './utils/register-components';
 // Import MicroApp component to trigger registration
 // The @customElement decorator will register it when the class is imported
 import { MicroApp } from './components/ui/components/runtime/MicroApp/MicroApp';
+import { MicroComponents } from './components/ui/components/runtime/MicroComponents/MicroComponents';
 
-// Export MicroApp component for programmatic access
-export { MicroApp };
+// Export MicroApp and MicroComponents components for programmatic access
+export { MicroApp, MicroComponents };
 
 // Export related types and utilities
 export { MicroAppStoreContext } from './micro-app/state/MicroAppStoreContext';
@@ -21,9 +22,10 @@ export { MicroAppRuntimeContext } from './micro-app/state/MicroAppRuntimeContext
 export { MicroAppPageManager } from './micro-app/state/MicroAppPageManager';
 export { MicroAppMessageBus } from './micro-app/messaging/MicroAppMessageBus';
 
-// Ensure the component is registered by accessing it
+// Ensure the components are registered by accessing them
 // This prevents tree-shaking from removing the registration
 if (typeof window !== 'undefined') {
-  // Touch the class to ensure it's not tree-shaken
+  // Touch the classes to ensure they're not tree-shaken
   void MicroApp;
+  void MicroComponents;
 }

--- a/micro-app-entry.ts
+++ b/micro-app-entry.ts
@@ -11,10 +11,10 @@ import './utils/register-components';
 // Import MicroApp component to trigger registration
 // The @customElement decorator will register it when the class is imported
 import { MicroApp } from './components/ui/components/runtime/MicroApp/MicroApp';
-import { MicroComponents } from './components/ui/components/runtime/MicroComponents/MicroComponents';
+import { MicroComponent } from './components/ui/components/runtime/MicroComponent/MicroComponent';
 
-// Export MicroApp and MicroComponents components for programmatic access
-export { MicroApp, MicroComponents };
+// Export MicroApp and MicroComponent components for programmatic access
+export { MicroApp, MicroComponent };
 
 // Export related types and utilities
 export { MicroAppStoreContext } from './micro-app/state/MicroAppStoreContext';
@@ -27,5 +27,5 @@ export { MicroAppMessageBus } from './micro-app/messaging/MicroAppMessageBus';
 if (typeof window !== 'undefined') {
   // Touch the classes to ensure they're not tree-shaken
   void MicroApp;
-  void MicroComponents;
+  void MicroComponent;
 }

--- a/utils/register-components.ts
+++ b/utils/register-components.ts
@@ -37,6 +37,6 @@ import "../components/ui/components/advanced/Collapse/Collapse";
 import "../components/ui/components/advanced/Collections/Collections";
 import "../components/ui/components/advanced/RefComponent/RefComponent";
 import "../components/ui/components/advanced/RichText/RichText";
-import "../components/ui/components/runtime/MicroComponents/MicroComponents";
+import "../components/ui/components/runtime/MicroComponent/MicroComponent";
 import "../components/ui/components/utility/Document/Document";
 import "../components/ui/components/ToastContainer/ToastContainer";

--- a/utils/register-components.ts
+++ b/utils/register-components.ts
@@ -37,5 +37,6 @@ import "../components/ui/components/advanced/Collapse/Collapse";
 import "../components/ui/components/advanced/Collections/Collections";
 import "../components/ui/components/advanced/RefComponent/RefComponent";
 import "../components/ui/components/advanced/RichText/RichText";
+import "../components/ui/components/runtime/MicroComponents/MicroComponents";
 import "../components/ui/components/utility/Document/Document";
 import "../components/ui/components/ToastContainer/ToastContainer";


### PR DESCRIPTION
- Create MicroComponents component that accepts an array of ComponentElement
- First component in array is treated as root/main
- Support optional isolated context for scoped variables
- Support initial vars for both global and isolated modes
- Register component in micro-app-entry.ts and register-components.ts