### PR TITLE
fix: execution preview node executions + mobile drag

### DIFF
--- a/services/constants.ts
+++ b/services/constants.ts
@@ -50,6 +50,8 @@ export const APIS_URL = {
   executeWorkflow: (id: string) => `${API_BASE}/api/v1/workflows/${id}/execute`,
   getWorkflowExecutions: (id: string) => `${API_BASE}/api/v1/workflows/${id}/executions`,
   getWorkflowExecution: (workflowId: string, execId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/executions/${execId}`,
+  getNodeExecutions: (workflowId: string, executionId: string) =>
+    `${API_BASE}/api/v1/workflows/${workflowId}/executions/${executionId}/nodes`,
   addWorkflowNode: (workflowId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/nodes`,
   updateWorkflowNode: (workflowId: string, nodeId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/nodes/${nodeId}`,
   deleteWorkflowNode: (workflowId: string, nodeId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/nodes/${nodeId}`,
@@ -186,8 +188,12 @@ export const APIS_URL = {
     `${API_BASE}/api/v1/logs/trace/${correlationId}`,
 
   // Workflow Triggers
-  getWorkflowTriggers: (workflowId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/triggers`,
+  getWorkflowTriggers: (workflowId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/trigger-defs`,
+  createTrigger: (workflowId: string) => `${API_BASE}/api/v1/workflows/${workflowId}/trigger-defs`,
+  updateTrigger: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}`,
   getTriggerStatus: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}/status`,
   activateTrigger: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}/activate`,
   deactivateTrigger: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}/deactivate`,
+  enableDevMode: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}/dev-mode`,
+  disableDevMode: (triggerId: string) => `${API_BASE}/api/v1/triggers/${triggerId}/dev-mode`,
 };


### PR DESCRIPTION
## Summary
- Add `getNodeExecutions` URL constant and `NodeExecutionResult` type + service method to runtime services
- Update nuraly-ui submodule for mobile palette touch drag-and-drop fix (NuralyUI#25)

## Test plan
- [ ] Execution preview loads node execution statuses correctly
- [ ] Mobile palette drag works in workflow editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)